### PR TITLE
Fix setup metadata repo URL.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ with open(os.path.join(dir_path, 'requirements.txt')) as fh:
 setup(
     name=__pkg_name__,
     version=__version__,
-    url='https://github.com/nanoporetech/{}'.format(__pkg_name__),
+    url='https://github.com/nanoporetech/{}'.format(__pkg_name__.replace('_', '-')),
     author=__author__,
     author_email='{}@nanoporetech.com'.format(__author__),
     description=__description__,


### PR DESCRIPTION
The URL in the setup metadata (and thus on pypi) is currently wrong since it uses `__pkg_name__` (`duplex_tools`) unmodified.

This is the least intrusive fix, but maybe not the best.

Found while processing the package update in Bioconda (https://github.com/bioconda/bioconda-recipes/pull/35562#pullrequestreview-1023279999).