### PR TITLE
Update dorado_stereo.sh

### DIFF
--- a/duplex_tools/dorado_stereo.sh
+++ b/duplex_tools/dorado_stereo.sh
@@ -92,11 +92,13 @@ if ! command -v duplex_tools pair > /dev/null; then
     exit 1;
 fi
 
-mkdir -p ${DUPLEX_DIR}
-mkdir -p ${SIMPLEX_UNMAPPED_MOVES_DIR}
-mkdir -p ${DUPLEX_DIR2}
-mkdir -p ${SIMPLEX_UNMAPPED_DIR}
-mkdir -p ${SPLITDUPLEX_DIR}
+if ! $dryflag; then
+    mkdir -p ${DUPLEX_DIR}
+    mkdir -p ${SIMPLEX_UNMAPPED_MOVES_DIR}
+    mkdir -p ${DUPLEX_DIR2}
+    mkdir -p ${SIMPLEX_UNMAPPED_DIR}
+    mkdir -p ${SPLITDUPLEX_DIR}
+fi
 
 # Stage 1 basecalling
 stage1_simplex="$DORADO basecaller $MODEL_LARGE $POD5 $DEVICE_STRING\


### PR DESCRIPTION
When running with the -n flag the code in it's current form will attempt to make all the directories even though the command line argument suggests no commands will be run. 

This change should prevent that from happening.

The additional problem is that if the folders do not exist for the output, dorado won't create them - but that is obviously an issue for the base caller.